### PR TITLE
remove # from word_separators, update year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2010-2014 Guillermo López-Anglada (Vintageous)
-Copyright (c) 2012-2019 FichteFoll <fichtefoll2@googlemail.com>
+Copyright (c) 2010-2014 Guillermo LÃ³pez-Anglada (Vintageous)
+Copyright (c) 2012-2021 FichteFoll <fichtefoll2@googlemail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
@@ -5,5 +5,5 @@
         { "selector": "meta.mapping.key punctuation.definition.string.begin" },
     ],
     "extensions": ["sublime-color-scheme"],
-    "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
+    "word_separators": "./\\()\"':,.;<>~!@$%^&*|+=[]{}`~?" // default without '-'
 }


### PR DESCRIPTION
I removed `#` from `word_separators` in `Sublime Text Color Scheme.sublime-settings` so hex colors can be selected completely. I also updated the `LICENSE` to 2021, although this will need to be updated again in 2 months.

Side question: can we get the next release out soon so the `block_caret_*` color scheme settings are recognized? LSP-json complains every time I save my color scheme...